### PR TITLE
Fix usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ This plugin aims to provide GPG signing for XSBT (SBT 0.11+ versions).  The plug
 
 ## Usage
 
-If you already have GPG configured, simply add the following to your `~/.sbt/plugins/project/build.sbt` file:
+If you already have GPG configured, simply add the following to your `~/.sbt/plugins/project/build.scala` file:
 
     import sbt._
+
     object PluginDef extends Build {
       override def projects = Seq(root)
       lazy val root = Project("plugins", file(".")) dependsOn(gpg)
-      lazy val gpg = file("git://github.com/jsuereth/xsbt-gpg-plugin.git#0.2")
+      lazy val gpg = uri("git://github.com/jsuereth/xsbt-gpg-plugin.git#0.2")
     }
 
 The plugin should wire into all your projects and sign files before they are deployed.   


### PR DESCRIPTION
- build.sbt should be build.scala
- file should be uri

Nice plugin.  Much better than my awkward attempt to register a signer with Ivy.
