### PR TITLE
ASCII-armor command line output

### DIFF
--- a/src/main/scala/GpgPlugin.scala
+++ b/src/main/scala/GpgPlugin.scala
@@ -19,7 +19,7 @@ class CommandLineGpgSigner(command: String) extends PgpSigner {
   def sign(file: File, signatureFile: File): File = {
       if (signatureFile.exists) IO.delete(signatureFile)
        // --output = sig file
-       Process(command, Seq("--detach-sign", "--output", signatureFile.getAbsolutePath, file.getAbsolutePath)).!
+       Process(command, Seq("--detach-sign", "--armor", "--output", signatureFile.getAbsolutePath, file.getAbsolutePath)).!
        signatureFile 
   }
   def generateKey(pubKey: File, secKey: File, identity: String, s: TaskStreams): Unit = 


### PR DESCRIPTION
The command line is currently outputting *.asc files, but they're not ASCII-armored.  This is inconsistent with the Bouncy Castle signer and also causes the signatures to be rejected by Maven Central.  Longer term, there could be settings for the suffix and whether to armor, but I think armoring is more correct in the current setup.
