### PR TITLE
Fix broken signing key hex parsing for key ids with MSB set

### DIFF
--- a/src/main/scala/PgpPlugin.scala
+++ b/src/main/scala/PgpPlugin.scala
@@ -135,5 +135,5 @@ object PgpPlugin extends Plugin {
   override val settings = allSettings
   
   def usePgpKeyHex(id: String) =
-    pgpSigningKey := Some(java.lang.Long.parseLong(id, 16))
+    pgpSigningKey := Some(new java.math.BigInteger(id, 16).longValue)
 }


### PR DESCRIPTION
For parsing signing key IDs specified as hex numbers we cannot use `Long.parseLong`, since all key id values with the most significant bit set will throw a NumberFormatException.
Fix: parse into BigInteger
