### PR TITLE
sbt 0.13 looks for plugins in the ~/.sbt/0.13 folder

### DIFF
--- a/src/jekyll/index.md
+++ b/src/jekyll/index.md
@@ -7,11 +7,24 @@ The `sbt-pgp` plugin provides PGP signing for SBT 0.12+.  Some OSS repositories 
 
 ## Installation ##
 
+###For sbt 0.12.x:
+
 Add the following to your `~/.sbt/plugins/gpg.sbt` file:
    
 ```
    addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 ```
+
+
+###For sbt 0.13.x:
+
+
+Add the following to your `~/.sbt/0.13/plugins/gpg.sbt` file:
+   
+```
+   addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+```
+
 
 ## Usage
 


### PR DESCRIPTION
I originally had my plugins in the regular `~/.sbt/plugins` folder and when I upgraded to sbt 0.13.5 the plugins were not loading.
After moving the plugin folder to the `0.13` folder, they loaded fine
