### PR TITLE
Upgraded sbt

### DIFF
--- a/gpg-library/src/main/scala/com/jsuereth/pgp/package.scala
+++ b/gpg-library/src/main/scala/com/jsuereth/pgp/package.scala
@@ -25,7 +25,7 @@ object PGP {
     }
     java.security.Security.addProvider(newProvider)
   } catch {
-    case t => error("Could not initialize bouncy castle encryption.")
+    case t: Throwable => error("Could not initialize bouncy castle encryption.")
   }
 
   /** This is a helper method used to make sure the above initialization happens. */

--- a/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/CommonParsers.scala
+++ b/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/CommonParsers.scala
@@ -13,7 +13,7 @@ object CommonParsers {
     try {
       ctx.publicKeyRing.publicKeys.view map (_.keyID) map ("%x" format (_)) toSeq
     } catch {
-      case _ => Seq.empty
+      case _: Throwable => Seq.empty
     }
   /** Parser for existing public key ids. */
   def existingPublicKeyId(ctx: PgpStaticContext) = 
@@ -25,7 +25,7 @@ object CommonParsers {
     try {
       ctx.publicKeyRing.publicKeys.view flatMap (_.userIDs) toSeq
     } catch {
-      case _ => Seq.empty
+      case _: Throwable => Seq.empty
     }
   
   def existingKeyIdOrUser(ctx: PgpStaticContext): Parser[String] =

--- a/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/SignKey.scala
+++ b/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/SignKey.scala
@@ -21,7 +21,7 @@ case class SignKey(pubKey: String, notation: (String,String)) extends PgpCommand
           try {
             ctx.secretKeyRing.secretKey.signPublicKey(key, notation, pw)
           } catch {
-            case t => 
+            case t: Throwable => 
               ctx.log.trace(t)
               ctx.log.error("Error signing key!")
               throw t

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.1


### PR DESCRIPTION
Upgraded sbt - not sure what version to upgrade to, so choose 0.13.1 by popular observation. :-)

The reason for this is so that sbt-pgp can be used where its dependencies (`net.databind`) do not conflict with 2.10 versions.
