### PR TITLE
Bump sbt-pgp to use sbt-core-next to grab input.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val plugin =
     settings(
       sbtPlugin := true,
       name := "sbt-pgp",
-      libraryDependencies += dispatchDependency,
+      libraryDependencies ++= Seq(dispatchDependency, sbtCoreNext.value),
       publishLocal <<= publishLocal.dependsOn(publishLocal in library)
     ).
     //settings(websiteSettings:_*).

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/SbtPgp.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/SbtPgp.scala
@@ -18,6 +18,7 @@ import PgpKeys._
 object SbtPgp extends AutoPlugin {
 
   override def trigger = allRequirements
+  override def requires = sbt.plugins.InteractionServicePlugin && sbt.plugins.IvyPlugin
   
   // Note - workaround for issues in sbt 0.13.5 autoImport
   object autoImportImpl {

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
@@ -10,6 +10,7 @@ import complete.DefaultParsers._
 import SbtHelpers._
 import PgpKeys._
 import com.jsuereth.pgp._
+import sbt.InteractionServiceKeys.interactionService
 
 /**
  * SBT Settings for doing PGP security tasks.  Signing, verifying, etc.
@@ -76,7 +77,7 @@ object PgpSettings {
       case _ => file(System.getProperty("user.home")) / ".sbt" / "gpg" / "secring.asc"
     },
     PgpKeys.pgpStaticContext <<= (PgpKeys.pgpPublicRing, PgpKeys.pgpSecretRing) apply SbtPgpStaticContext.apply,
-    PgpKeys.pgpCmdContext <<= (PgpKeys.pgpStaticContext, PgpKeys.pgpPassphrase, streams) map SbtPgpCommandContext.apply
+    PgpKeys.pgpCmdContext <<= (PgpKeys.pgpStaticContext, interactionService, PgpKeys.pgpPassphrase, streams) map SbtPgpCommandContext.apply
   )
   
   

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/package.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/package.scala
@@ -5,11 +5,6 @@ import sbt._
 package object pgp {
   /** Default extension for PGP signatures. */
   val gpgExtension = ".asc"
-
-  /** Reads the passphrase from the console. */
-  def readPassphrase(): Array[Char] = System.out.synchronized {
-    (SimpleReader.readLine("Please enter your PGP passphrase> ", Some('*')) getOrElse error("No password provided.")).toCharArray
-  }
   
   // Helper to figure out how to run GPG signing...
   def isWindows = System.getProperty("os.name").toLowerCase.indexOf("windows") != -1

--- a/pgp-plugin/src/main/scala/sbt/HackInteractionAccess.scala
+++ b/pgp-plugin/src/main/scala/sbt/HackInteractionAccess.scala
@@ -1,0 +1,7 @@
+package sbt
+
+import sbt.plugins.CommandLineUIServices
+
+object HackInteractionAccess {
+  def defaultInteraction: InteractionService = CommandLineUIServices
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -14,6 +14,10 @@ object PgpCommonSettings extends AutoPlugin {
     val bouncyCastlePgp = "org.bouncycastle" % "bcpg-jdk15on" % "1.51"
     val specs2 = "org.specs2" %% "specs2" % "2.3.11"
     val sbtIo  = "org.scala-sbt" % "io" % "0.13.6"
+
+    val sbtCoreNext = Def.setting {
+      Defaults.sbtPluginExtra("org.scala-sbt" % "sbt-core-next" % "0.1.1", sbtBinaryVersion.value, scalaBinaryVersion.value)
+    }
   }
 
   override def projectSettings =


### PR DESCRIPTION
Review by @eed3si9n cc> @havocp 


Note: It's a big hacky, because we need to preserve the binary compatibility of the constructor, since users are loading use via the *global* sbt project, rather than a particular one, and we wind up with version conflicts.