### PR TITLE
Use Scala cross building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 language: scala
 script:
-  - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" test scripted
+  - sbt "++${TRAVIS_SCALA_VERSION}" test scripted
 matrix:
   include:
-  - env: SBT_VERSION="0.13.16"
-    jdk: openjdk7
+  - jdk: openjdk7
     scala: 2.10.6
-  - env: SBT_VERSION="1.0.0-RC3"
-    jdk: oraclejdk8
+  - jdk: oraclejdk8
     scala: 2.12.3

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 This plugin aims to provide PGP signing for versions of SBT >= 0.12.
 
 Please see the [documentation](http://www.scala-sbt.org/sbt-pgp) for more information.
+
+## Developing
+
+This plugin uses ordinary Scala cross building to cross build against different sbt versions, not the built in sbt cross building, since that only works for projects that are just sbt plugins, it doesn't work for projects that have ordinary Scala libraries too.
+
+So, to cross build this project you can run `+publishLocal` or `+scripted` etc.

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ lazy val library =
   Project("library", file("gpg-library"))
     .settings(
       name := "pgp-library",
-      // scalaVersion := "2.12.2",
       libraryDependencies ++= Seq(bouncyCastlePgp, gigahorseOkhttp,
         specs2 % Test, sbtIo % Test),
       libraryDependencies ++= {
@@ -30,7 +29,6 @@ lazy val plugin =
     .settings(
       sbtPlugin := true,
       name := "sbt-pgp",
-      // scalaVersion := "2.12.2",
       libraryDependencies += gigahorseOkhttp,
       libraryDependencies ++= {
         (sbtBinaryVersion in pluginCrossBuild).value match {

--- a/notes/1.1.0.markdown
+++ b/notes/1.1.0.markdown
@@ -2,6 +2,6 @@ https://github.com/sbt/sbt-pgp/compare/v1.0.1...v1.1.0-M1
 
 ### Fixes and minor enhancements
 
-- sbt-pgp 1.1.0-M1 is cross built for sbt 0.13 and 1.0.0-M5. sbt 0.13 version now requires JDK7. #100 by @eed3si9n
+- sbt-pgp 1.1.0 is cross built for sbt 0.13 and 1.0.0. sbt 0.13 version now requires JDK7. #100 by @eed3si9n
 - Use Gigahorse for HTTP client available for both 2.10 and 2.12.
 - Supports `skip in publish := true`. This allows skipping publishing _without_ depending on sbt-pgp. #101 by @eed3si9n

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -28,6 +28,15 @@ object PgpCommonSettings extends AutoPlugin {
       scalacOptions in Compile := Seq("-feature", "-deprecation", "-Xlint"),
       publishMavenStyle := false,
       bintrayOrganization := Some("sbt"),
-      bintrayRepository := "sbt-plugin-releases"
+      bintrayRepository := "sbt-plugin-releases",
+      // Because we're both a library and an sbt plugin, we use crossScalaVersions rather than crossSbtVersions for
+      // cross building. So you can use commands like +scripted.
+      crossScalaVersions := Seq("2.10.6", "2.12.3"),
+      sbtVersion in pluginCrossBuild := {
+        scalaBinaryVersion.value match {
+          case "2.10" => "0.13.16"
+          case "2.12" => "1.0.0"
+        }
+      }
     )
 }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -38,12 +38,11 @@ object Release {
     // TODO - Ensure we're releasing on JDK 6, so we're binary compatible.
     // First check to ensure we have a sane publishing environment...
     "checkBintrayCredentials" ::
-    "test" :: "scripted" ::
-    //"publishLocal" :: "scripted" ::
+    "+test" :: "+scripted" ::
     // TODO - Signed tags, possibly using pgp keys?
     ("git tag " + tag) ::
     "reload" ::
-    "all library/publishSigned plugin/publishSigned" ::
+    "+ all library/publishSigned plugin/publishSigned" ::
     "bintrayPublishAllStaged" ::
     ("git push origin " + tag) ::
   	state

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")

--- a/src/jekyll/index.md
+++ b/src/jekyll/index.md
@@ -7,6 +7,13 @@ The `sbt-pgp` plugin provides PGP signing for SBT 0.12+.  Some OSS repositories 
 
 ## Installation ##
 
+###For sbt 1.0.0+:
+
+Add the following to your `~/.sbt/1.0/plugins/gpg.sbt` file:
+   
+```
+   addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+```
 
 ###For sbt 0.13.5+:
 
@@ -14,7 +21,7 @@ The `sbt-pgp` plugin provides PGP signing for SBT 0.12+.  Some OSS repositories 
 Add the following to your `~/.sbt/0.13/plugins/gpg.sbt` file:
    
 ```
-   addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+   addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 ```
 
 


### PR DESCRIPTION
This makes the plugin use Scala cross building, rather than sbt cross building, to do cross building. It sets `sbtVersion in pluginCrossBuild` explicitly based on what the current `scalaVersion` is. So the result is you can run `+scripted` to cross build against sbt 1.0 and sbt 0.13.

I've also updated the release process to use this, added a note about it to README, and updated the docs in preparation for a 1.1.0 release.