### PR TITLE
Nicer feedback when failing to decrypt a key

### DIFF
--- a/gpg-library/src/main/scala/com/jsuereth/pgp/PrivateKey.scala
+++ b/gpg-library/src/main/scala/com/jsuereth/pgp/PrivateKey.scala
@@ -10,7 +10,7 @@ import org.bouncycastle.openpgp._
 import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory
 import org.bouncycastle.openpgp.operator.jcajce.{JcaPGPContentSignerBuilder, JcaPGPDigestCalculatorProviderBuilder, JcePBESecretKeyDecryptorBuilder, JcePublicKeyDataDecryptorFactoryBuilder}
 
-class IncorrectPassphraseException(msg: String) extends RuntimeException(msg)
+class IncorrectPassphraseException(msg: String, cause: Throwable) extends RuntimeException(msg, cause)
 
 
 /** A SecretKey that can be used to sign things and decrypt messages. */
@@ -233,7 +233,7 @@ class SecretKey(val nested: PGPSecretKey) {
       nested.extractPrivateKey(decryptorFactory)
     }
     catch {
-      case e: PGPException if e.getMessage.contains("checksum mismatch") => throw new IncorrectPassphraseException("Incorrect passhprase")
+      case e: PGPException if e.getMessage.contains("checksum mismatch") => throw new IncorrectPassphraseException("Incorrect passhprase", e)
     }
 
   def userIDs = new Traversable[String] {

--- a/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/SignKey.scala
+++ b/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/SignKey.scala
@@ -16,10 +16,11 @@ case class SignKey(pubKey: String, notation: (String,String)) extends PgpCommand
     } yield ring -> key
     val newpubringcol = matches match {
       case Seq((ring, key), _*) =>
-        val newkey = ctx withPassphrase { pw => 
+        val signingKey = ctx.secretKeyRing.secretKey
+        val newkey = ctx.withPassphrase(signingKey.keyID) { pw =>
         ctx.log.info("Signing key: " + key)
           try {
-            ctx.secretKeyRing.secretKey.signPublicKey(key, notation, pw)
+            signingKey.signPublicKey(key, notation, pw)
           } catch {
             case t: Throwable =>
               ctx.log.trace(t)

--- a/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/context.scala
+++ b/pgp-plugin/src/main/scala/com/jsuereth/pgp/cli/context.scala
@@ -40,7 +40,7 @@ trait PgpCommandContext extends PgpStaticContext with UICommandContext {
   /** Prompts user to input a passphrase. */
   def inputPassphrase: Array[Char]
   /** Perform an action with a passphrase.  This will ensure caching or other magikz */
-  def withPassphrase[U](f: Array[Char] => U): U
+  def withPassphrase[U](keyId: Long)(f: Array[Char] => U): U
   def addPublicKeyRing(key: PublicKeyRing): Unit = {
     key.masterKey match {
       case Some(mk) if publicKeyRing.publicKeys.map(_.keyID).toSet.apply(mk.keyID) =>

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/SbtPgpCommandContext.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/SbtPgpCommandContext.scala
@@ -34,14 +34,14 @@ case class SbtPgpCommandContext(
     case _ => sys.error("Empty passphrase. aborting...")
   }
 
-  def withPassphrase[U](f: Array[Char] => U): U = {
+  def withPassphrase[U](key: Long)(f: Array[Char] => U): U = {
     retry[U, IncorrectPassphraseException](3){
       PasswordCache.withValue(
         key = ctx.secretKeyRingFile.getAbsolutePath,
         default = optPassphrase getOrElse inputPassphrase)(f)
     } match {
       case Right(u) => u
-      case Left(e) => sys.error("Wrong passphrase. aborting...")
+      case Left(e) => throw new IllegalArgumentException(s"Wrong passphrase for key ${key.toHexString.toUpperCase} in ${ctx.secretKeyRingFile.getAbsolutePath}: ${e.getMessage}. aborting...", e)
     }
   }
 


### PR DESCRIPTION
The problem turned out to be https://github.com/sbt/sbt-pgp/issues/72:
I removed keys from my keyring using the gpg command-line tool, but
because I was on gpg 2.2 that didn't affect my ~/.gnupg/secring.gpg.

Not sure if we can/should point to that specifically/prominently?