### PR TITLE
WIP: Unbreak usage with gpg-agent 2.1.x

### DIFF
--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSigner.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSigner.scala
@@ -19,9 +19,9 @@ class CommandLineGpgSigner(command: String, agent: Boolean, secRing: String, opt
   def sign(file: File, signatureFile: File, s: TaskStreams): File = {
     if (signatureFile.exists) IO.delete(signatureFile)
     val passargs: Seq[String] = (optPassphrase map { passArray => passArray mkString "" } map { pass => Seq("--passphrase", pass) }) getOrElse Seq.empty
-    val ringargs: Seq[String] = Seq("--no-default-keyring", "--keyring", secRing)
+    // val ringargs: Seq[String] = Seq("--no-default-keyring", "--keyring", secRing)
     val keyargs: Seq[String] = optKey map (k => Seq("--default-key", "0x%x" format(k))) getOrElse Seq.empty
-    val args = passargs ++ ringargs ++ Seq("--detach-sign", "--armor") ++ (if(agent) Seq("--use-agent") else Seq.empty) ++ keyargs
+    val args = passargs ++ Seq("--detach-sign", "--armor") ++ (if(agent) Seq("--use-agent") else Seq.empty) ++ keyargs
     sys.process.Process(command, args ++ Seq("--output", signatureFile.getAbsolutePath, file.getAbsolutePath)) ! s.log match {
       case 0 => ()
       case n => sys.error("Failure running gpg --detach-sign.  Exit code: " + n)


### PR DESCRIPTION
Ok, so this is just for discussion, etc.

The current master breaks for me when using `useGpgAgent := true`. I get the following error message:

```
    [error] gpg: expected public key but found secret key - must stop
```

Applying the patch in this PR seems to work around the problem and allows signing to proceed, but it's obviously not the "correct" solution.

I'm just not sure about what the correct solution would be, so I just wanted to ask for feedback.

I mean, I could always just add yet another option, but it seems that the whole "specify a keyring file", etc. bits of GnuPG aren't really the way to do things with GnuPG 2.1.x+, so perhaps it would be a good idea to start cleaning up the options, removing obsolete ones, etc. AFAICT all that's actually needed for GnuPG is a way to specify which key to use (via e-mail/ID) and then let it take care of the rest.

(I would expect such work to go into a hypothetical sbt-pgp 1.2.x or even 2.0.0. I'm actually considering 'proper' fork of sbt-pgp to do all of the cleanup, etc. but it'd obviously be a lot better to only have one sbt-pgp :) )

@eed3si9n What do you think? Any ideas how to go about this?