### PR TITLE
Use newer versions of GNU PG

### DIFF
--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpKeys.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpKeys.scala
@@ -28,7 +28,8 @@ object PgpKeys {
   val gpgCommand = SettingKey[String]("gpg-command", "The path of the GPG command to run", BSetting)
   val useGpg = SettingKey[Boolean]("use-gpg", "If this is set to true, the GPG command line will be used.", ASetting)
   val useGpgAgent = SettingKey[Boolean]("use-gpg-agent", "If this is set to true, the GPG command line will expect a GPG agent for the password.", BSetting)
-  
+  val gpgAncient = SettingKey[Boolean]("gpg-ancient","Set this to true if you use a gpg version older than 2.1.")
+
   // Checking PGP Signatures options
   val signaturesModule = TaskKey[GetSignaturesModule]("signatures-module", "", CTask)
   val updatePgpSignatures = TaskKey[UpdateReport]("update-pgp-signatures", "Resolves and optionally retrieves signatures for artifacts, transitively.", CTask)

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
@@ -71,11 +71,12 @@ object PgpSettings {
       case None => file(System.getProperty("user.home")) / ".gnupg"
     }
     Seq(
+      PgpKeys.gpgAncient := !useGpg.value, //I believe the java pgp library does depend on the old implementation.
       PgpKeys.pgpPassphrase := None,
       PgpKeys.pgpSelectPassphrase := PgpKeys.pgpPassphrase.value orElse
         (Credentials.forHost(credentials.value, "pgp") map (_.passwd.toCharArray)),
       PgpKeys.pgpPublicRing := gnuPGHome / "pubring.gpg",
-      PgpKeys.pgpSecretRing := gnuPGHome / "secring.gpg",
+      PgpKeys.pgpSecretRing := {if (gpgAncient.value) gnuPGHome / "secring.gpg" else gnuPGHome / "pubring.gpg"},
       PgpKeys.pgpSigningKey := None,
       PgpKeys.pgpReadOnly := true,
       // TODO - Are these all ok to place in global scope?

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala
@@ -75,8 +75,8 @@ object PgpSettings {
       PgpKeys.pgpPassphrase := None,
       PgpKeys.pgpSelectPassphrase := PgpKeys.pgpPassphrase.value orElse
         (Credentials.forHost(credentials.value, "pgp") map (_.passwd.toCharArray)),
-      PgpKeys.pgpPublicRing := gnuPGHome / "pubring.gpg",
-      PgpKeys.pgpSecretRing := {if (gpgAncient.value) gnuPGHome / "secring.gpg" else gnuPGHome / "pubring.gpg"},
+      PgpKeys.pgpPublicRing := {if (gpgAncient.value) gnuPGHome / "pubring.gpg" else gnuPGHome / "pubring.kbx"},
+      PgpKeys.pgpSecretRing := {if (gpgAncient.value) gnuPGHome / "secring.gpg" else gnuPGHome / "pubring.kbx"},
       PgpKeys.pgpSigningKey := None,
       PgpKeys.pgpReadOnly := true,
       // TODO - Are these all ok to place in global scope?

--- a/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSigner.scala
+++ b/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSigner.scala
@@ -22,9 +22,10 @@ class CommandLineGpgSigner(command: String, agent: Boolean, secRing: String, opt
     val ringargs: Seq[String] = Seq("--no-default-keyring", "--keyring", secRing)
     val keyargs: Seq[String] = optKey map (k => Seq("--default-key", "0x%x" format(k))) getOrElse Seq.empty
     val args = passargs ++ ringargs ++ Seq("--detach-sign", "--armor") ++ (if(agent) Seq("--use-agent") else Seq.empty) ++ keyargs
-    sys.process.Process(command, args ++ Seq("--output", signatureFile.getAbsolutePath, file.getAbsolutePath)) ! s.log match {
+    val allArguments: Seq[String] = args ++ Seq("--output", signatureFile.getAbsolutePath, file.getAbsolutePath)
+    sys.process.Process(command, allArguments) ! s.log match {
       case 0 => ()
-      case n => sys.error("Failure running gpg --detach-sign.  Exit code: " + n)
+      case n => sys.error(s"Failure running '${command + " " + allArguments.mkString(" ")}'.  Exit code: " + n)
     }
     signatureFile
   }


### PR DESCRIPTION
Changes where made for gnupg >= 2.1
This hopes to fix #72.
A SettingKey `gpgAncient` was added that you can set to true if you want to old behaviour. (Disclaimer: sorry for the slightly opinionated name. I could not think of something else. If someone knows a better one I am happy to change it)

Edit: I also added some code to make debugging the gpg command easier in the future.
 