### PR TITLE
Fix misleading loglevel given to gpg command stderr

### DIFF
--- a/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSigner.scala
+++ b/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSigner.scala
@@ -1,5 +1,6 @@
 package com.jsuereth.sbtpgp
 
+import scala.sys.process.ProcessLogger
 import sbt._
 import Keys._
 import com.jsuereth.pgp.cli.PgpCommandContext
@@ -43,7 +44,7 @@ class CommandLineGpgSigner(
     val args = passargs ++ ringargs ++ Seq("--detach-sign", "--armor") ++ (if (agent) Seq("--use-agent") else Seq.empty) ++ keyargs
     val allArguments: Seq[String] = args ++ Seq("--output", signatureFile.getAbsolutePath, file.getAbsolutePath)
     import sbt.sbtpgp.Compat._ // needed for sbt 0.13
-    sys.process.Process(command, allArguments) ! s.log match {
+    sys.process.Process(command, allArguments) ! ProcessLogger(s.log.info(_)) match {
       case 0 => ()
       case n => sys.error(s"Failure running '${command + " " + allArguments.mkString(" ")}'.  Exit code: " + n)
     }


### PR DESCRIPTION
Fixes #174

Execution results look like this:

Without this fix

```
sbt:test> signedArtifacts
[info] Wrote /path/to/sbt-pgp/src/sbt-test/sbt-pgp/credentials/target/scala-2.13/test_2.13-1.0.pom
[error] gpg: using "..." as default secret key for signing
[error] gpg: using "..." as default secret key for signing
[error] gpg: using "..." as default secret key for signing
[error] gpg: using "..." as default secret key for signing
[success] Total time: 1 s, completed 2020/10/18 17:39:40
```

With this fix

```
sbt:test> signedArtifacts
[info] Wrote /path/to/sbt-pgp/src/sbt-test/sbt-pgp/credentials/target/scala-2.13/test_2.13-1.0.pom
[info] gpg: using "..." as default secret key for signing
[info] gpg: using "..." as default secret key for signing
[info] gpg: using "..." as default secret key for signing
[info] gpg: using "..." as default secret key for signing
[success] Total time: 1 s, completed 2020/10/18 17:40:33
```
