### PR TITLE
Implement gpg 2 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val plugin = (project in file("sbt-pgp"))
       }
     },
     publishLocal := publishLocal.dependsOn(publishLocal in library).value,
+    scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dproject.version=${version.value}"
   )
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-pgp/issues/173 / https://github.com/sbt/sbt-pgp/issues/178
https://www.gnupg.org/documentation/manuals/gnupg/GPG-Esoteric-Options.html#GPG-Esoteric-Options
> --passphrase string
> Since Version 2.1 the --pinentry-mode also needs to be set to loopback.

This attemps to detect the version number from the --version output, and adds `--pinentry-mode loopback` to the argument.