### PR TITLE
Add homepage to commonSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val library = (project in file("gpg-library"))
 
 lazy val commonSettings = Seq(
   organization := "com.jsuereth",
+  homepage := Some(url("https://github.com/sbt/sbt-pgp")),
   Compile / scalacOptions := Seq("-feature", "-deprecation", "-Xlint"),
   publishMavenStyle := false,
   bintrayOrganization := Some("sbt"),


### PR DESCRIPTION
This enables Scala Steward to link to this page, the GitHub release notes
and version diff in its pull requests.