### PR TITLE
Pass in --yes

### DIFF
--- a/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSigner.scala
+++ b/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSigner.scala
@@ -66,7 +66,7 @@ class CommandLineGpgSigner(
       // --passphrase
       // Since Version 2.1 the --pinentry-mode also needs to be set to loopback.
       if (isLegacyGpg) Seq("--batch", "--passphrase", pass)
-      else Seq("--batch", "--pinentry-mode", "loopback", "--passphrase", pass)
+      else Seq("--batch", "--yes", "--pinentry-mode", "loopback", "--passphrase", pass)
     }) getOrElse Seq.empty
     val ringargs: Seq[String] =
       optRing match {


### PR DESCRIPTION
Problem
-------
Supposedly gpg 2.3.8 fails to sign without `--yes` according to https://github.com/sbt/sbt-pgp/issues/199.

Solution
--------
Pass in `--yes`.