### PR TITLE
Update Bouncy Castle to a near recent version with which compilation …

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
         "com.eed3si9n" %% "gigahorse-okhttp" % "0.7.0"
     }
   )
-  val bouncyCastlePgp = "org.bouncycastle" % "bcpg-jdk15on" % "1.69"
+  val bouncyCastlePgp = "org.bouncycastle" % "bcpg-jdk18on" % "1.78.1"
   val specs2 = "org.specs2" %% "specs2-core" % "4.20.8"
   val sbtIo = "org.scala-sbt" %% "io" % "1.10.0"
   val parserCombinators = Def.setting(


### PR DESCRIPTION
Recent Veracode scan gave vulnerabilities in the transitive dependency for bouncy castle. Updating the jar to a recent version. 
Vulnerabilities - Public Data
CVE-2024-30172                                 High Risk            Denial Of Service (DoS)        Bouncy Castle Provider 1.69
CVE-2023-33201                                 Medium Risk       LDAP Injection                 Bouncy Castle Provider 1.69
CVE-2024-29857                                 Medium Risk       Denial Of Service (DoS)        Bouncy Castle Provider 1.69
CVE-2024-30171                                 Medium Risk       Observable Discrepancy         Bouncy Castle Provider 1.69
CVE-2023-33202                                 Medium Risk       Denial Of Service (DoS)        Bouncy Castle Provider 1.69