### PR TITLE
Add `-Xsource:3` option. Fix old varargs splice syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ val commonSettings = Def.settings(
     scalaBinaryVersion.value match {
       case "2.12" =>
         Seq(
+          "-Xsource:3",
           "-release:8",
           "-Xlint"
         )

--- a/gpg-library/src/main/scala/com/jsuereth/pgp/hkp/client.scala
+++ b/gpg-library/src/main/scala/com/jsuereth/pgp/hkp/client.scala
@@ -90,7 +90,7 @@ uid:Terry Suereth (CE2008) <tsuereth@digipen.edu>:1137516901::
 Note: Type bits/keyID    Date
    */
   private[this] def initiateRequest(cmd: HkpCommand): Request =
-    Gigahorse.url(serverUrl + cmd.url).addQueryString(cmd.vars.toList: _*)
+    Gigahorse.url(serverUrl + cmd.url).addQueryString(cmd.vars.toList*)
 
   private[this] def initiateFormPost(cmd: HkpCommand): Request =
     Gigahorse

--- a/sbt-pgp/src/main/scala/com/jsuereth/pgp/cli/CommonParsers.scala
+++ b/sbt-pgp/src/main/scala/com/jsuereth/pgp/cli/CommonParsers.scala
@@ -18,7 +18,7 @@ object CommonParsers {
 
   /** Parser for existing public key ids. */
   def existingPublicKeyId(ctx: PgpStaticContext) =
-    token(hexanum, "<keyid>").examples(hexPublicKeyIds(ctx): _*).map(java.lang.Long.parseLong(_, 16))
+    token(hexanum, "<keyid>").examples(hexPublicKeyIds(ctx)*).map(java.lang.Long.parseLong(_, 16))
 
   lazy val keyIdOrUser: Parser[String] = token(NotSpace, "<key id/user>")
 
@@ -30,7 +30,7 @@ object CommonParsers {
     }
 
   def existingKeyIdOrUser(ctx: PgpStaticContext): Parser[String] =
-    keyIdOrUser.examples((userIds(ctx) ++ hexPublicKeyIds(ctx)): _*)
+    keyIdOrUser.examples((userIds(ctx) ++ hexPublicKeyIds(ctx))*)
   // TODO - ensure urls are urls
   lazy val hkpUrl = token(NotSpace, "<hkp server url>")
 

--- a/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSettings.scala
+++ b/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/PgpSettings.scala
@@ -46,7 +46,7 @@ object PgpSettings {
       val (h, t) = (fs.head, fs.tail)
       if (t.isEmpty) h
       else if (h.exists) h
-      else fallbackFiles(t: _*)
+      else fallbackFiles(t*)
     }
 
     Seq(


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html